### PR TITLE
Add Fylings — African company registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
  <li><a href="https://www.experte.com/email-finder">Experte Email Finder</a></li>
  <li><a href="https://register.fca.org.uk/s">FCA</a></li>
  <li><a href="https://corruptiondata.eu/follow-the-money/">Follow The Money</a></li> 
+ <li><a href="https://www.fylings.com/">Fylings (Africa - 18+ national registries)</a></li>
  <li><a href="https://uk.globaldatabase.com/company?name=">Global Company Database</a></li>
  <li><a href="https://panjiva.com/search">Global Trade Data Search</a></li>
  <li><a href="https://portal.guernseyregistry.com/">Guernsey Registry</a></li>


### PR DESCRIPTION
Adds **Fylings** to the company tools list.

The list is excellent for the UK and Europe but has almost no Africa coverage. Fylings fills that gap: a free platform that searches and verifies companies across **18+ official African national registries** (Nigeria's CAC, Tanzania's BRELA, Mauritius's CBRD, Senegal's RCCM, and more), showing the official registry source and a last-verified date on every record. It also surfaces beneficial ownership, government-contract awards, and sanctions screening.

Site: https://www.fylings.com — free, no signup for search. Entry inserted alphabetically.