### PR TITLE
Add Company Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
  <li><a href="https://ceoemail.com/">CEOmail</a></li>
  <li><a href="https://companycheck.co.uk/">Company Check</a></li>
  <li><a href="https://companydirectorcheck.com/search?find=">Company Director Check</a></li>
+ <li><a href="https://records.knowyourcustomer.com/">Company Records (149 jurisdictions - free search, live registry documents)</a></li>
  <li><a href="https://companiesintheuk.co.uk/">Companies House</a></li>
  <li><a href="https://companyresearcher.exa.ai/">Company Researcher</a></li>
  <li><a href="https://www.corporationwiki.com/">Corporation Wiki</a></li>


### PR DESCRIPTION
Adds [Company Records](https://records.knowyourcustomer.com/) to the Company-Business-OSINT list, next to the other company-registry search tools.

Company Records provides company search across 149 jurisdictions, each with its own coverage page. Searching is free and anonymous with no login; on purchase, the company report and the underlying official filings are retrieved live from the official register at the moment of purchase, not from a cached or aggregated database. A single purchase starts at US$19, with no subscription.

Disclosure: this is an affiliated submission; I work with Know Your Customer Limited, which operates this service.

The list leans UK, so worth noting the United Kingdom is covered (documents from Companies House), alongside 148 other jurisdictions.
